### PR TITLE
fix 04_fix_testcode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@
 
 # Ignore .idea files
 .idea
+
+/vendor/bundle
+

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :task do
+    association :project
     title { 'Task' }
     status { rand(2) }
     from = Date.parse("2019/08/01")

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     deadline { Random.rand(from..to) }
 
     trait :complete do
-      status { 'done' }
+      status { :done }
       completion_date = Time.current.yesterday
     end
   end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -5,5 +5,10 @@ FactoryBot.define do
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")
     deadline { Random.rand(from..to) }
+
+    trait :complete do
+      status { 'done' }
+      completion_date = Time.current.yesterday
+    end
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  # pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,4 +59,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.include ApplicationHelper
 end

--- a/spec/support/driver_setting.rb
+++ b/spec/support/driver_setting.rb
@@ -1,7 +1,7 @@
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     # driven_by(:rack_test)
-    # driven_by(:selenium_chrome)
-    driven_by(:selenium_chrome_headless)
+    driven_by(:selenium_chrome)
+    # driven_by(:selenium_chrome_headless)
   end
 end

--- a/spec/support/driver_setting.rb
+++ b/spec/support/driver_setting.rb
@@ -1,7 +1,7 @@
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     # driven_by(:rack_test)
-    driven_by(:selenium_chrome)
-    # driven_by(:selenium_chrome_headless)
+    # driven_by(:selenium_chrome)
+    driven_by(:selenium_chrome_headless)
   end
 end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Task', type: :system do
   let(:project) { create(:project) }
-  let(:task)    { create(:task, project_id: project.id) }
+  let(:task)    { create(:task) }
 
   describe 'Task一覧' do
     context '正常系' do
@@ -54,8 +54,6 @@ RSpec.describe 'Task', type: :system do
   describe 'Task編集' do
     context '正常系' do
       it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit edit_project_task_path(project, task)
         fill_in 'Deadline', with: Time.current
         click_button 'Update Task'
@@ -75,7 +73,7 @@ RSpec.describe 'Task', type: :system do
 
       it '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do
         # task = FactoryBot.create(:task, project_id: project.id, status: :done, completion_date: Time.current.yesterday)
-        task = create(:task, :complete, project_id: project.id )
+        task = create(:task, :complete)
         visit edit_project_task_path(project, task)
         select 'todo', from: 'Status'
         click_button 'Update Task'

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -88,7 +88,6 @@ RSpec.describe 'Task', type: :system do
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
       it 'Taskが削除されること' do
-        # 下記行を前述letで置き換えようとすると失敗する。projectの方は問題ない。
         task = FactoryBot.create(:task, project_id: project.id)
         visit project_tasks_path(project)
         click_link 'Destroy'

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -1,27 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe 'Task', type: :system do
+  let(:project) { create(:project) }
+  let(:task)    { create(:task, project_id: project.id) }
+
   describe 'Task一覧' do
     context '正常系' do
       it '一覧ページにアクセスした場合、Taskが表示されること' do
-        # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit project_tasks_path(project)
         expect(page).to have_content task.title
         expect(Task.count).to eq 1
         expect(current_path).to eq project_tasks_path(project)
       end
 
-      xit 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
-        # FIXME: テストが失敗するので修正してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
+      it 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
         visit project_path(project)
         click_link 'View Todos'
-        expect(page).to have_content task.title
-        expect(Task.count).to eq 1
-        expect(current_path).to eq project_tasks_path(project)
+        within_window(windows.last) do
+          expect(page).to have_content task.title
+          expect(Task.count).to eq 1
+          expect(current_path).to eq project_tasks_path(project)
+        end
       end
     end
   end
@@ -29,8 +28,6 @@ RSpec.describe 'Task', type: :system do
   describe 'Task新規作成' do
     context '正常系' do
       it 'Taskが新規作成されること' do
-        # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
         visit project_tasks_path(project)
         click_link 'New Task'
         fill_in 'Title', with: 'test'
@@ -45,9 +42,6 @@ RSpec.describe 'Task', type: :system do
   describe 'Task詳細' do
     context '正常系' do
       it 'Taskが表示されること' do
-        # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit project_task_path(project, task)
         expect(page).to have_content(task.title)
         expect(page).to have_content(task.status)
@@ -59,22 +53,18 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task編集' do
     context '正常系' do
-      xit 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
-        # FIXME: テストが失敗するので修正してください
+      it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         project = FactoryBot.create(:project)
         task = FactoryBot.create(:task, project_id: project.id)
         visit edit_project_task_path(project, task)
         fill_in 'Deadline', with: Time.current
         click_button 'Update Task'
         click_link 'Back'
-        expect(find('.task_list')).to have_content(Time.current.strftime('%Y-%m-%d'))
+        expect(find('.task_list')).to have_content(short_time(Time.current))
         expect(current_path).to eq project_tasks_path(project)
       end
 
       it 'ステータスを完了にした場合、Taskの完了日に今日の日付が登録されること' do
-        # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit edit_project_task_path(project, task)
         select 'done', from: 'Status'
         click_button 'Update Task'
@@ -84,9 +74,8 @@ RSpec.describe 'Task', type: :system do
       end
 
       it '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do
-        # TODO: FactoryBotのtraitを利用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id, status: :done, completion_date: Time.current.yesterday)
+        # task = FactoryBot.create(:task, project_id: project.id, status: :done, completion_date: Time.current.yesterday)
+        task = create(:task, :complete, project_id: project.id )
         visit edit_project_task_path(project, task)
         select 'todo', from: 'Status'
         click_button 'Update Task'
@@ -100,13 +89,13 @@ RSpec.describe 'Task', type: :system do
   describe 'Task削除' do
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
-      xit 'Taskが削除されること' do
-        project = FactoryBot.create(:project)
+      it 'Taskが削除されること' do
+        # 下記行を前述letで置き換えようとすると失敗する。projectの方は問題ない。
         task = FactoryBot.create(:task, project_id: project.id)
         visit project_tasks_path(project)
         click_link 'Destroy'
         page.driver.browser.switch_to.alert.accept
-        expect(page).not_to have_content task.title
+        expect(find('.task_list')).not_to have_content(task.title)
         expect(Task.count).to eq 0
         expect(current_path).to eq project_tasks_path(project)
       end


### PR DESCRIPTION
FIXME:
it 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること'
=> 'view Todos'が別ウィンドウで開いているので、検証するウィンドウを直近で開いたウィンドウにて行う様修正。

it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること'
=>日時の表記が違っていたので、アプリ側のコードに合わせて修正。

it 'Taskが削除されること'
=>ページのタイトルをカウントしていると思ったので、scopeを調整。

TODO:
各所letを用いてリファクタリング
`it 'Taskが削除されること' do`のみletで置き換えると

`1) Task Task削除 正常系 Taskが削除されること
     Failure/Error: click_link 'Destroy'
     
     Capybara::ElementNotFound:
       Unable to find link "Destroy"`
のエラーが出てしまったので、置き換えていません。

traitを使ってのリファクタリング
spec/factories/task.rb内にtraitを追記